### PR TITLE
Refactor/prefetching

### DIFF
--- a/src/app/rotation/page.tsx
+++ b/src/app/rotation/page.tsx
@@ -1,16 +1,30 @@
+// import RotationClientPage from "@/components/RotationClientPage";
 import RotationClientPage from "@/components/RotationClientPage";
 import fetchRotationChampion from "@/utils/riotApi";
 import { fetchChampion } from "@/utils/serverApi";
+// import { fetchChampion } from "@/utils/serverApi";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 
 const serverPage = async () => {
+  const queryClient = new QueryClient();
   try {
-    const rotationChamps = await fetchRotationChampion();
-    const champs = await fetchChampion();
+    await queryClient.prefetchQuery({
+      queryKey: ["rototaionChamps"],
+      queryFn: fetchRotationChampion,
+    });
+
+    await queryClient.prefetchQuery({
+      queryKey: ["champs"],
+      queryFn: fetchChampion,
+    });
     return (
-      <RotationClientPage
-        rotationInitial={rotationChamps}
-        champsInitial={champs}
-      />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <RotationClientPage />
+      </HydrationBoundary>
     );
   } catch (error) {
     console.log("데이터를 불러오는데 실패했습니다.", error);

--- a/src/components/RotationClientPage.tsx
+++ b/src/components/RotationClientPage.tsx
@@ -2,23 +2,14 @@
 
 import Loading from "@/app/rotation/loading";
 import { useChampionsDataQuery, useRotationDataQuery } from "@/hooks/queries";
-import { Champion } from "@/types/Champions";
 import conversionFreeChampion from "@/utils/conversionFreeChampion";
 import { Suspense } from "react";
 import ChampionCard from "./ChampionCard";
 
-export type RotationProps = {
-  rotationInitial: [number[], number[], number];
-  champsInitial: Champion[];
-};
+const RotationClientPage = () => {
+  const { data: rotationData } = useRotationDataQuery();
 
-const RotationClientPage = ({
-  rotationInitial,
-  champsInitial,
-}: RotationProps) => {
-  const { data: rotationData } = useRotationDataQuery({ rotationInitial });
-
-  const { data: champions } = useChampionsDataQuery({ champsInitial });
+  const { data: champions } = useChampionsDataQuery();
 
   const freeChampionsId = rotationData[0];
   const freeChampionForNewbieId = rotationData[1];

--- a/src/hooks/queries.tsx
+++ b/src/hooks/queries.tsx
@@ -1,29 +1,18 @@
 "use client";
-import { Champion } from "@/types/Champions";
 import fetchRotationChampion from "@/utils/riotApi";
 import { fetchChampion } from "@/utils/serverApi";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
-export const useRotationDataQuery = ({
-  rotationInitial,
-}: {
-  rotationInitial: [number[], number[], number];
-}) => {
+export const useRotationDataQuery = () => {
   return useSuspenseQuery({
     queryKey: ["rotationId"],
     queryFn: () => fetchRotationChampion(),
-    initialData: rotationInitial,
   });
 };
 
-export const useChampionsDataQuery = ({
-  champsInitial,
-}: {
-  champsInitial: Champion[];
-}) => {
+export const useChampionsDataQuery = () => {
   return useSuspenseQuery({
     queryKey: ["champions"],
     queryFn: () => fetchChampion(),
-    initialData: champsInitial,
   });
 };

--- a/src/utils/riotApi.ts
+++ b/src/utils/riotApi.ts
@@ -1,11 +1,14 @@
 import RIOT_CONSTANT from "@/constants/RIOT_CONSTANT";
 import { RotationChampionData } from "@/types/Championrotation";
-
 //CSR
 const fetchRotationChampion = async (): Promise<
   [number[], number[], number]
 > => {
-  const res = await fetch(`${RIOT_CONSTANT.BASE_URL}/api/rotation`);
+  const res = await fetch(`${RIOT_CONSTANT.RIOT_ROTATION_CHAMPION_URL}`, {
+    headers: {
+      "X-Riot-Token": `${process.env.NEXT_PUBLIC_RIOT_API_KEY}` || "",
+    },
+  });
   const data: RotationChampionData = await res.json();
   return [
     data.freeChampionIds,


### PR DESCRIPTION
## #️⃣ Issue Number

- #23 

## 📝 요약(Summary)

서버 컴포넌트에서 routeHandler 호출은 안티 패턴이므로 routerHandler 호출 대신 바로 api 받아오기
prefetching 을 사용하여 hydrateBoundary로 감싸고 props drilling을 제거
prefetching 사용으로 initialData 불필요

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

